### PR TITLE
Use array.slice instead of splice when creating displayHeaders

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -17,7 +17,7 @@ var app = angular.module('reportcard', [ 'nvd3ChartDirectives','ui.bootstrap', '
       { key: "pctTicket", value: "% Tickets" }
     ];
 
-    reportCard.displayHeaders = reportCard.csvHeaders.splice(1);
+    reportCard.displayHeaders = reportCard.csvHeaders.slice(1);
 
     reportCard.resetEffort = function() {
       reportCard.effort = [


### PR DESCRIPTION
For #29, I used splice instead of slice to make the array of
displayHeaders. While both _return_ the same sub-array, splice removes
elements from the object, while slice does not alter it.

Fixes #31
